### PR TITLE
[Unify] Unified official docs version and style, fixed links in git

### DIFF
--- a/02_maven_proxies/README.MD
+++ b/02_maven_proxies/README.MD
@@ -1,5 +1,4 @@
-Official documentation:
-[https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2/html-single/Configuring_and_Running_JBoss_Fuse/index.html#FESBFabricMavenProxyConfig]
+[Official documentation about maven proxies](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html-single/Configuring_and_Running_JBoss_Fuse/index.html#FESBFabricMavenProxyConfig)
 
 JBoss Fuse uses many different properties to configure Maven repositories. This is to give flexibility to each single component.  The final result might look confusing to the use that is not sure which property it has to configure, but with a brief recap, it's easier to not get lost:
 

--- a/08_external_git/README.MD
+++ b/08_external_git/README.MD
@@ -1,4 +1,4 @@
-Official documentation: [https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html/Fabric_Guide/Git-External.html]
+[Official documentation about external git](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html/Fabric_Guide/Git-External.html)
 
 JBoss Fuse uses an internal git repository to store information about two important areas:
 * Fabric runtime configuration - fabric versions, profiles associated with the versions, etc.
@@ -22,8 +22,8 @@ There are currently (6.2.1 version of JBoss Fuse) two options of authentication 
 
 ### Configuring environment
 
-If you want to use SSH key authentication, add your _public_ SSH key (its default location is `~/.ssh/id_rsa.pub`) to your (GitHub profile)
-[https://github.com/settings/ssh]. Then you should test if your connection is working using the ssh command. You should see an output similar to
+If you want to use SSH key authentication, add your _public_ SSH key (its default location is `~/.ssh/id_rsa.pub`) to your [GitHub profile]
+(https://github.com/settings/ssh). Then you should test if your connection is working using the ssh command. You should see an output similar to
 this one:
 
 ```bash
@@ -58,4 +58,4 @@ JBossFuse:karaf@root> fabric:create --external-git-url git@github.com:gituser/fa
 After the container is provisioned successfully, you can check your repository in GitHub. You should already see a new branch called *1.0* which
 contains all the profiles defined in the 1.0 version of fabric.
 
-For more info about the Git in Fabric, please see the (official documentation)[https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html/Fabric_Guide/Git.html#Git-HowItWorks] about this topic.
+For more info about the Git in Fabric, please see the [official documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html/Fabric_Guide/Git.html#Git-HowItWorks) about this topic.

--- a/12_resolvers/README.MD
+++ b/12_resolvers/README.MD
@@ -1,6 +1,4 @@
-##### official docs
-[https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2/html/Console_Reference/ConsoleFabricContainerResolverSet.html]
-
+[Official documentation about resolvers](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2.1/html/Console_Reference/ConsoleFabricContainerResolverSet.html)
 
 ##### Description
 An operating system instance can have multiple ip addresses. For this reason, the answer to "what is that box ip address?" is not that trivial.  


### PR DESCRIPTION
Hi @paoloantinori ,

I saw I messed up the brackets forming the links in the git example, so I corrected it and unified the documentation versions and style
